### PR TITLE
Fix for display of rrssb

### DIFF
--- a/templates/joomla/css/custom.css
+++ b/templates/joomla/css/custom.css
@@ -86,6 +86,11 @@ body.site {
     margin-top: -100px;
     padding-top: 100px;
 }
+
+/*fix for rrssb display*/
+.rrssb-buttons {
+	display: inline-block;
+}
 /*End 2017 changes*/
 
 .thumbnails .thumbnail,.breadcrumb {


### PR DESCRIPTION
Display was (nearly) ok on desktop, but text was displayed at the right of the buttons for screens under 767px.