### PR TITLE
Update nightlybuilds.php for 5.3 and 5.4

### DIFF
--- a/plugins/content/nightlybuilds/nightlybuilds.php
+++ b/plugins/content/nightlybuilds/nightlybuilds.php
@@ -124,11 +124,11 @@ class PlgContentNightlyBuilds extends CMSPlugin
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_major_list.xml';
 					break;
 
-				case '5.3':
+				case '5.4':
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_minor_list.xml';
 					break;
 
-				case '5.2':
+				case '5.3':
 				case '4.4':
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_patch_list.xml';
 					break;


### PR DESCRIPTION
### This PR has to be merged AFTER the release of 5.3.0 stable on Tuesday, April 15.

### PR https://github.com/joomla/update.joomla.org/pull/402 should be merged before this one here.

Change next minor from 5.3 to 5.4.

Change next patch from 5.2 to 5.3.