### PR TITLE
Rotate nightly build update sites after the 5.4.0 and 6.0.0 stable releases

### DIFF
--- a/plugins/content/nightlybuilds/nightlybuilds.php
+++ b/plugins/content/nightlybuilds/nightlybuilds.php
@@ -120,16 +120,16 @@ class PlgContentNightlyBuilds extends CMSPlugin
 			// Set the updateserver per branch
 			switch ($branch)
 			{
-				case '6.0':
+				case '7.0':
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_major_list.xml';
 					break;
 
-				case '5.4':
+				case '6.1':
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_minor_list.xml';
 					break;
 
-				case '5.3':
-				case '4.4':
+				case '6.0':
+				case '5.4':
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_patch_list.xml';
 					break;
 


### PR DESCRIPTION
This pull request (PR) has to be merged together with https://github.com/joomla/update.joomla.org/pull/424 after the releases of 5.4.0 stable and 6.0.0 stable on October 14.

4.4 and 5.3 nightly builds are removed from next patch.

5.4 is moved from next minor to next patch, and 6.0 is moved from next major to next patch.

6.1 is added to next minor and also to next major. Nightly build have already been enabled for 6.1.

As long as we do not have 7.x nightly builds, next major will not be shown on the nightly builds download page.