### PR TITLE
Update nightly build update sites after the 5.4.5 and 6.1.0 stable releases

### DIFF
--- a/plugins/content/nightlybuilds/nightlybuilds.php
+++ b/plugins/content/nightlybuilds/nightlybuilds.php
@@ -124,11 +124,11 @@ class PlgContentNightlyBuilds extends CMSPlugin
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_major_list.xml';
 					break;
 
-				case '6.1':
+				case '6.2':
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_minor_list.xml';
 					break;
 
-				case '6.0':
+				case '6.1':
 				case '5.4':
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_patch_list.xml';
 					break;


### PR DESCRIPTION
This pull request (PR) has to be merged together with https://github.com/joomla/update.joomla.org/pull/446 after the 5.4.5 and 6.1.0 stable releases on Tuesday, April 14, 2026.

6.0 is replaced by 6.1 for next patch, and 6.1 is replaced by 6.2 for next minor.

It is an alternative to PR #58 .

This PR is ready, but I will leave it in draft status until Tuesday, April 14, 2026.